### PR TITLE
Hpc install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,37 @@ MMCA_with_vaccination [https://github.com/PGcastioni/MMCA_with_vaccination/]([ur
 
 This project is an attempt to extend the functionalities of the previous version. Currently, this version provides a standard configuration format for defining a model and provides a simple set of command line scripts to generate configuration templates and run the model.
 
+
+### Installing
+
+To install EpiSim.jl, follow these steps:
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/your-repo/EpiSim.jl.git
+   cd EpiSim.jl
+   ```
+
+2. Run the installation script:
+   ```
+   ./install.sh [HPC_ACCOUNT_NAME]
+   ```
+   
+   Note: The `HPC_ACCOUNT_NAME` argument is required only when running on BSC HPC systems.
+
+   This is because the compile time is long enough that we need to schedule a slurm job for it.
+
+The compilation process (`install.jl`) creates a single precompiled executable:
+
+- Builds the application in a `build` folder
+- Creates a symlink named `episim` in the target directory (default is the current directory)
+
+After installation, you can run EpiSim using the `episim` command.
+
+
 ### Using EpiSim.jl
 
-EpiSim works as a command line frontend to lunch simulations. It provides a simple JSON based config format to define an instance of a model. The config format included a common or core sets of parameter and specific parameters required by the different engies supported by EpiSim.jl.
+EpiSim works as a command line frontend to launch simulations. It provides a simple JSON based config format to define an instance of a model. The config format included a common or core sets of parameter and specific parameters required by the different engines supported by EpiSim.jl.
 
 ### The `epiconfig.json` format
 ```

--- a/hpc_utils.sh
+++ b/hpc_utils.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+# BSC login nodes
+
+# WIFI-enabled login node
+WIFI_NODE="glogin4"
+
+LOGIN_NODES=("glogin1" "glogin2" "glogin3")
+LOGIN_NODES+=($WIFI_NODE)
+
+in_hpc_bsc() {
+	for node in "${LOGIN_NODES[@]}"; do
+		if [[ $(hostname) == "$node" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# useful to know if we can install dependencies in this env...
+in_hpc_wifi() {
+	[[ $(hostname) == "$WIFI_NODE" ]]
+	return $?
+}
+

--- a/install.jl
+++ b/install.jl
@@ -1,8 +1,9 @@
 using Pkg
 
+# run this in an interactive session in MN5 or it will time-out !!
+# note that you should have installed the dependencies before running this script
 Pkg.activate(".")
-
-Pkg.add(url="https://github.com/Epi-Sim/MMCACovid19Vac.jl")
+Pkg.add()
 Pkg.instantiate()
 Pkg.precompile()
 

--- a/install.jl
+++ b/install.jl
@@ -3,9 +3,6 @@ using Pkg
 # run this in an interactive session in MN5 or it will time-out !!
 # note that you should have installed the dependencies before running this script
 Pkg.activate(".")
-Pkg.add()
-Pkg.instantiate()
-Pkg.precompile()
 
 using PackageCompiler
 using ArgParse

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+# script args
+# $1: hpc account name: for srun to compile the project
+ACCOUNT=$1
+PROJDIR=$(dirname $0)
+
 source hpc_utils.sh
 
 MMCACovid19Vac="https://github.com/Epi-Sim/MMCACovid19Vac.jl"
 
 if ! in_hpc_bsc || in_hpc_wifi; then
     echo "Installing MMCACovid19Vac package..."
-    if julia --project . -e "using Pkg; Pkg.add(url=\"$MMCACovid19Vac\"); Pkg.instantiate(); Pkg.precompile()"; then
+    if julia --project=${PROJDIR} -e "using Pkg; Pkg.add(url=\"${MMCACovid19Vac}\"); Pkg.instantiate(); Pkg.precompile()"; then
         echo "Engine installed successfully."
     else
         echo "Engine installation failed. Please check the error messages above."
@@ -19,8 +24,16 @@ fi
 
 echo "Compiling the package..."
 if in_hpc_bsc; then
-    echo "Starting interactive session"
-    srun -t 00:30:00 -A $USER --qos gp_bscls -c 4 -n 1 julia install.jl
+    if [ -z "$ACCOUNT" ]; then
+        echo "Error: Please pass an HPC account name as the first argument."
+        exit 1
+    fi
+    srun --unbuffered \
+        -t 00:30:00 \
+        -A $ACCOUNT \
+        --qos gp_bscls \
+        -c 4 -n 1 \
+        julia install.jl -c |&cat
 else
-    julia install.jl
+    julia install.jl -c
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source hpc_utils.sh
+
+MMCACovid19Vac="https://github.com/Epi-Sim/MMCACovid19Vac.jl"
+
+if ! in_hpc_bsc || in_hpc_wifi; then
+    echo "Installing MMCACovid19Vac package..."
+    if julia --project . -e "using Pkg; Pkg.add(url=\"$MMCACovid19Vac\"); Pkg.instantiate(); Pkg.precompile()"; then
+        echo "Engine installed successfully."
+    else
+        echo "Engine installation failed. Please check the error messages above."
+        exit 1
+    fi
+else
+    echo "Skipping engine installation in this environment."
+    echo "Make sure the engines are already installed !!!"
+fi
+
+echo "Compiling the package..."
+if in_hpc_bsc; then
+    echo "Starting interactive session"
+    srun -t 00:30:00 -A $USER --qos gp_bscls -c 4 -n 1 julia install.jl
+else
+    julia install.jl
+fi


### PR DESCRIPTION
enable install in HPC by submitting the compile step as a slurm job (because it takes ~30 minutes).

NOTE: there is currently a bug with julia in HPC: Before loading Julia, git works fine
```bash
$ git clone https://github.com/Epi-Sim/EpiSim.jl.git
> Cloning into 'EpiSim.jl'...
> etc...
```

However:
```bash

$ module load julia
$ git clone https://github.com/Epi-Sim/EpiSim.jl.git
> Cloning into 'EpiSim.jl'... fatal: unable to access 'https://github.com/Epi-Sim/EpiSim.jl.git/': Cert verify failed: BADCERT_NOT_TRUSTED

$ module unload julia
$ git clone https://github.com/Epi-Sim/EpiSim.jl.git
> Cloning into 'EpiSim.jl'...
> etc...
``` 