### PR TITLE
moving global vars to common

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -7,3 +7,14 @@ struct MMCACovid19Engine <: AbstractEngine end
 
 struct NetCDFFormat <: AbstractOutputFormat end
 struct HDF5Format <: AbstractOutputFormat end
+
+
+const ENGINES  = ["MMCACovid19Vac", "MMCACovid19"]
+const COMMANDS = ["run", "setup", "init"]
+
+
+# Define a dictionary to map engine names to their types
+const ENGINE_TYPES = Dict(
+    "MMCACovid19Vac" => MMCACovid19VacEngine,
+    "MMCACovid19" => MMCACovid19Engine
+)

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -6,15 +6,6 @@ using MMCACovid19Vac
 
 include("io.jl")
 
-const ENGINES  = ["MMCACovid19Vac", "MMCACovid19"]
-const COMMANDS = ["run", "setup", "init"]
-
-
-# Define a dictionary to map engine names to their types
-const ENGINE_TYPES = Dict(
-    "MMCACovid19Vac" => MMCACovid19VacEngine,
-    "MMCACovid19" => MMCACovid19Engine
-)
 
 function get_engine(engine_name::String)
     engine_type = get(ENGINE_TYPES, engine_name, nothing)


### PR DESCRIPTION
Refactoring global variables from `engine.jl` to `common.jl`

```const ENGINES  = ["MMCACovid19Vac", "MMCACovid19"]
const COMMANDS = ["run", "setup", "init"]

# Define a dictionary to map engine names to their types
const ENGINE_TYPES = Dict(
    "MMCACovid19Vac" => MMCACovid19VacEngine,
    "MMCACovid19" => MMCACovid19Engine
)```
