### PR TITLE
round nᵢᵍ so it can be converted to int

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -272,6 +272,7 @@ function run_engine(::MMCACovid19Engine, config::Dict, npi_params::NPI_Params, n
     sᵢ = metapop_df[:, "area"]
     # Subpopulation by age strata
     nᵢᵍ = copy(transpose(Array{Float64,2}(metapop_df[:, G_coords])))
+    nᵢᵍ = round.( nᵢᵍ)
     # Age Contact Matrix
     C = Float64.(mapreduce(permutedims, vcat, pop_params_dict["C"]))
     # Average number of contacts per strata


### PR DESCRIPTION
When the populations are big enough the engine MMCACovid19 is not able to convert the variables nᵢᵍ to int, so we need to round it first